### PR TITLE
replaced `tune.parameters` boolean with "all" to run on grf 1.0+

### DIFF
--- a/Example.R
+++ b/Example.R
@@ -1,28 +1,42 @@
-# Download current version from Github
-library(devtools)
-install_github(repo="MCKnaus/CATEs")
-library(CATEs)
+rm(list = ls())
+library(LalRUtils)
+source("R/IATEs.R")
+source("R/CATEs_utils.R")
 
-# %%
-# Generate training sample
+libreq(glmnet, grf, caret)
+
+# %% # Generate training sample
 n = 4000; p = 20
-x_tr = matrix(rnorm(n * p), n, p)
-tau_tr = 1 / (1 + exp(-x_tr[, 3]))
-d_tr = rbinom(n ,1, 1 / (1 + exp(-x_tr[, 1] - x_tr[, 2])))
-y_tr = pmax(x_tr[, 2] + x_tr[, 3], 0) + rowMeans(x_tr[, 4:6]) / 2 + d_tr * tau_tr + rnorm(n)
+x_t = matrix(rnorm(n * p), n, p)
+tau_t = 1 / (1 + exp(-x_t[, 3]))
+d_t = rbinom(n ,1, 1 / (1 + exp(-x_t[, 1] - x_t[, 2])))
+y_t = pmax(x_t[, 2] + x_t[, 3], 0) + rowMeans(x_t[, 4:6]) / 2 + d_t * tau_t + rnorm(n)
 
-# %%
-# Generate validation sample of same size
-x_val = matrix(rnorm(n * p), n, p)
-tau_val = 1 / (1 + exp(-x_val[, 3]))
+# %% # Generate validation sample of same size
+x_v     = matrix(rnorm(n * p), n, p)
+tau_v   = 1 / (1 + exp(-x_v[, 3]))
 
-# Apply all estimators to the training sample and predict IATEs for validation sample
-iates_mat = IATEs(y_tr,d_tr,x_tr,tau_tr,x_val)
+# %% without true τ_train (for use in applications)
+iates_list = IATEs(y_t, d_t, x_t, x_v)
+iates_list  |>  str()
+iates_df = as.data.frame(do.call(cbind, iates_list))
+iates_df |> str()
 
-# %%
-# Calculate and print mean MSEs
-mMSE = colMeans((iates_mat - tau_val)^2)
-names(mMSE) = colnames(iates_mat)
-mMSE*1000
+# 'data.frame':	4000 obs. of  11 variables:
+#  $ RF CMR       : num  0.181 0.389 1.3 1.047 0.419 ...
+#  $ CF           : num  0.502 0.381 0.716 0.965 0.532 ...
+#  $ RF MOM IPW   : num  0.343 0.244 2.164 0.365 0.534 ...
+#  $ RF MOM DR    : num  0.399 0.353 1.066 0.414 0.483 ...
+#  $ CF LC        : num  0.415 0.333 0.605 0.475 0.47 ...
+#  $ LASSO CMR    : num  0.503 -0.144 1.478 0.624 0.33 ...
+#  $ LASSO MOM IPW: num  0.594 0.076 1.156 0.425 0.691 ...
+#  $ LASSO MOM DR : num  0.442 0.222 0.844 0.514 0.462 ...
+#  $ LASSO MCM    : num  0.6586 0.0472 1.266 0.4265 0.7341 ...
+#  $ LASSO MCM EA : num  0.36 0.224 0.686 0.453 0.398 ...
+#  $ LASSO RL     : num  0.357 0.301 0.614 0.493 0.38 ...
+#
 
-# %%
+# %% # Calculate and print mean MSEs
+mMSE = colMeans((iates_df - tau_v)^2)
+names(mMSE) = colnames(iates_df)
+round(mMSE*1000, 2)  |> t()

--- a/Example.R
+++ b/Example.R
@@ -3,6 +3,7 @@ library(devtools)
 install_github(repo="MCKnaus/CATEs")
 library(CATEs)
 
+# %%
 # Generate training sample
 n = 4000; p = 20
 x_tr = matrix(rnorm(n * p), n, p)
@@ -10,6 +11,7 @@ tau_tr = 1 / (1 + exp(-x_tr[, 3]))
 d_tr = rbinom(n ,1, 1 / (1 + exp(-x_tr[, 1] - x_tr[, 2])))
 y_tr = pmax(x_tr[, 2] + x_tr[, 3], 0) + rowMeans(x_tr[, 4:6]) / 2 + d_tr * tau_tr + rnorm(n)
 
+# %%
 # Generate validation sample of same size
 x_val = matrix(rnorm(n * p), n, p)
 tau_val = 1 / (1 + exp(-x_val[, 3]))
@@ -17,9 +19,10 @@ tau_val = 1 / (1 + exp(-x_val[, 3]))
 # Apply all estimators to the training sample and predict IATEs for validation sample
 iates_mat = IATEs(y_tr,d_tr,x_tr,tau_tr,x_val)
 
+# %%
 # Calculate and print mean MSEs
 mMSE = colMeans((iates_mat - tau_val)^2)
 names(mMSE) = colnames(iates_mat)
 mMSE*1000
 
-
+# %%

--- a/R/CATEs_utils.R
+++ b/R/CATEs_utils.R
@@ -87,25 +87,25 @@ nuisance_cf_grf <- function(y,d,x,index,
 
     fit_p = do.call(regression_forest,c(list(X=x[-index[[i]],,drop=F],
                                              Y=d[-index[[i]]]),
-                                        tune.parameters = TRUE,
+                                        tune.parameters = "all",
                                         args_p))
     np[index[[i]],1] = predict(fit_p,x[index[[i]],,drop=F])$prediction
 
     fit_y = do.call(regression_forest,c(list(X=x[-index[[i]],,drop=F],
                                              Y=y[-index[[i]]]),
-                                        tune.parameters = TRUE,
+                                        tune.parameters = "all",
                                         args_y))
     np[index[[i]],2] = predict(fit_y,x[index[[i]],,drop=F])$prediction
 
     fit_y0 = do.call(regression_forest,c(list(X=x[-index[[i]],,drop=F][d[-index[[i]]] == 0,,drop=F],
                                               Y=y[-index[[i]]][d[-index[[i]]] == 0]),
-                                         tune.parameters = TRUE,
+                                         tune.parameters = "all",
                                          args_y0))
     np[index[[i]],3] = predict(fit_y0,x[index[[i]],,drop=F])$prediction
 
     fit_y1 = do.call(regression_forest,c(list(X=x[-index[[i]],,drop=F][d[-index[[i]]] == 1,,drop=F],
                                               Y=y[-index[[i]]][d[-index[[i]]] == 1]),
-                                         tune.parameters = TRUE,
+                                         tune.parameters = "all",
                                          args_y1))
     np[index[[i]],4] = predict(fit_y1,x[index[[i]],,drop=F])$prediction
     # Think about predicting also for the other treatment category in the other fold and take the average
@@ -243,7 +243,7 @@ rl_glmnet = function(y,d,x,np,xnew,args_tau=list()) {
 
 mom_ipw_grf = function(y,d,x,np,xnew,args_tau=list()) {
   mo = y * (d-np[,"p_hat"]) / (np[,"p_hat"]*(1-np[,"p_hat"]))
-  fit_tau = do.call(regression_forest,c(list(X=x,Y=mo),tune.parameters = TRUE,args_tau))
+  fit_tau = do.call(regression_forest,c(list(X=x,Y=mo),tune.parameters = "all",args_tau))
   iate = predict(fit_tau,xnew)$prediction
   return(iate)
 }
@@ -265,7 +265,7 @@ mom_ipw_grf = function(y,d,x,np,xnew,args_tau=list()) {
 
 mom_dr_grf = function(y,d,x,np,xnew,args_tau=list()) {
   mo = np[,"y1_hat"] - np[,"y0_hat"] + d * (y-np[,"y1_hat"]) / np[,"p_hat"] - (1-d) * (y-np[,"y0_hat"]) / (1-np[,"p_hat"])
-  fit_tau = do.call(regression_forest,c(list(X=x,Y=mo),tune.parameters = TRUE,args_tau))
+  fit_tau = do.call(regression_forest,c(list(X=x,Y=mo),tune.parameters = "all",args_tau))
   iate = predict(fit_tau,xnew)$prediction
   return(iate)
 }
@@ -283,7 +283,7 @@ mom_dr_grf = function(y,d,x,np,xnew,args_tau=list()) {
 #' @param args_y0 List of arguments passed to estimate outcome model of non-treated
 #'
 #' @return Returns n x 4 matrix containing the nuisance parameters
-#' 
+#'
 #' @export
 
 cf_dml1 = function(est,y,d,x,np,xnew,index,args_tau=list()) {
@@ -301,4 +301,3 @@ cf_dml1 = function(est,y,d,x,np,xnew,index,args_tau=list()) {
   }
   return(iate)
 }
-

--- a/R/CATEs_utils.R
+++ b/R/CATEs_utils.R
@@ -1,3 +1,4 @@
+# %%
 #' This function creates the nuisance parameters p(x), mu(x), and mu_d(x)
 #' via cross-fitting using the \code{\link{glmnet}} package
 #'
@@ -20,17 +21,16 @@ nuisance_cf_glmnet <- function(y,d,x,index,
                                args_y=list(),
                                args_y0=list(),
                                args_y1=list()) {
-
-
   np = matrix(NA,length(d),4)
   colnames(np) = c("p_hat","y_hat","y0_hat","y1_hat")
 
   for(i in 1:length(index)) {
-    # P-score
+    # P-score - fit leaving out index i
     fit_p = do.call(cv.glmnet,c(list(x=x[-index[[i]],,drop=F],
                                      y=d[-index[[i]]],
                                      family="binomial"),
                                 args_p))
+    # predict on i
     np[index[[i]],1] = predict(fit_p,x[index[[i]],,drop=F], s = "lambda.min", type = "response")
 
     # Outcome
@@ -55,6 +55,7 @@ nuisance_cf_glmnet <- function(y,d,x,index,
 }
 
 
+# %%
 
 #' This function creates the nuisance parameters p(x), mu(x), and mu_d(x)
 #' via cross-fitting using the \code{\link{grf}} package
@@ -114,6 +115,7 @@ nuisance_cf_grf <- function(y,d,x,index,
   return(np)
 }
 
+# %%
 
 #' Implementation of MOM IPW using the \code{\link{glmnet}} package
 #'
@@ -136,6 +138,7 @@ mom_ipw_glmnet = function(y,d,x,np,xnew,args_tau=list()) {
   return(iate)
 }
 
+# %%
 
 #' Implementation of MOM DR using the \code{\link{glmnet}} package
 #'
@@ -158,6 +161,7 @@ mom_dr_glmnet = function(y,d,x,np,xnew,args_tau=list()) {
   return(iate)
 }
 
+# %%
 
 #' Implementation of MCM using the \code{\link{glmnet}} package
 #'
@@ -181,6 +185,8 @@ mcm_glmnet = function(y,d,x,np,xnew,args_tau=list()) {
   return(iate)
 }
 
+# %%
+
 #' Implementation of MCM with efficiency augmentation using the \code{\link{glmnet}} package
 #'
 #' @param y Vector of outcome values
@@ -203,6 +209,7 @@ mcm_ea_glmnet = function(y,d,x,np,xnew,args_tau=list()) {
   return(iate)
 }
 
+# %%
 
 #' Implementation of R-learning using the \code{\link{glmnet}} package
 #'
@@ -226,6 +233,7 @@ rl_glmnet = function(y,d,x,np,xnew,args_tau=list()) {
   return(iate)
 }
 
+# %%
 
 #' Implementation of MOM IPW using the \code{\link{grf}} package
 #'
@@ -248,6 +256,7 @@ mom_ipw_grf = function(y,d,x,np,xnew,args_tau=list()) {
   return(iate)
 }
 
+# %%
 
 #' Implementation of MOM DR using the \code{\link{grf}} package
 #'
@@ -270,6 +279,7 @@ mom_dr_grf = function(y,d,x,np,xnew,args_tau=list()) {
   return(iate)
 }
 
+# %%
 
 #' This function implements the 50:50 cross-fitting
 #'
@@ -286,13 +296,13 @@ mom_dr_grf = function(y,d,x,np,xnew,args_tau=list()) {
 #'
 #' @export
 
-cf_dml1 = function(est,y,d,x,np,xnew,index,args_tau=list()) {
+cf_dml1 = function(est, y, d, x, np, xnew, index, args_tau=list()) {
 
-  iate = matrix(0,length(d),1)
+  iate = matrix(0, length(d), 1)
 
   for (i in 1:length(index)) {
     iate = iate + 1/length(index) *
-                  do.call(est,list(y[index[[i]]],
+                  do.call(est,  list(y[index[[i]]],
                           d[index[[i]]],
                           x[index[[i]],,drop=F],
                           np[index[[i]],],
@@ -301,3 +311,5 @@ cf_dml1 = function(est,y,d,x,np,xnew,index,args_tau=list()) {
   }
   return(iate)
 }
+
+# %%

--- a/R/IATEs.R
+++ b/R/IATEs.R
@@ -1,74 +1,120 @@
-#' This function produces the predicted values of all 13 estimator considered in KLS
+#' This function produces the predicted values of CATE estimators on a validation set X
 #'
 #' @param y_t Vector of training outcome values
 #' @param d_t Vector of training treament indicators
 #' @param x_t Matrix of training covariates (N x p matrix)
 #' @param x_v Matrix of validation covariates (N x p matrix)
+#' @param tau_t (optional) Vector of training treatment effects
+#' @param estimators Character vector of length e with names of estimators to fit - defaults to all supported
 #' @import grf glmnet caret
-#'
-#' @return Returns n x 13 matrix containing the IATEs of the validation sample
-#'
+#' @return Returns list with e vectors containing the IATEs of the validation sample
 #' @export
 
-IATEs <- function(y_t,d_t,x_t,tau_t,x_v) {
+IATEs <- function(y_t, d_t, x_t, x_v, tau_t = NULL,
+    estimators = c("RF CMR", "RF MOM IPW", "RF MOM DR","CF","CF LC",
+                   "LASSO CMR", "LASSO MOM IPW", "LASSO MOM DR",
+                   "LASSO MCM", "LASSO MCM EA", "LASSO RL"),
+    nFolds = 2
+    ) {
+  # return list with vectors - easy to coerce to matrix when necessary
+  IATEs = list()
+  if(!is.null(tau_t)) { # true TEs provided - simulation study
+    # Infeasible RF
+    rf_inf = regression_forest(x_t, tau_t)
+    IATEs[['RF Inf']] = as.numeric(predict(rf_inf, x_v)$predictions)
+    # Infeasible Lasso
+    lasso_inf = cv.glmnet(x_t, tau_t)
+    IATEs[['LASSO Inf']] = as.numeric(predict(lasso_inf, x_v))
+  }
 
-  # Initialize matrix to store predicted IATEs of 13 estimators
-  iates_mat = matrix(NA,n,13)
-  colnames(iates_mat) =  c("RF Inf","RF CMR","RF MOM IPW","RF MOM DR","CF","CF LC",
-                           "Lasso Inf","Lasso CMR","Lasso MOM IPW","Lasso MOM DR",
-                           "Lasso MCM","Lasso MCM EA","Lasso RL")
+  # split for nuisance function estimation
+  index = caret::createFolds(y_t, k = nFolds)
 
+  ######################################################################
   ### RF Forest based methods
-  # Infeasible RF
-  rf_inf = regression_forest(x_t, tau_t)
-  iates_mat[,1] = predict(rf_inf, x_v)$predictions
+  ######################################################################
 
-  # CMR Random Forest
-  rf0 = regression_forest(x_t[d_t==0,], y_t[d_t==0])
-  rf1 = regression_forest(x_t[d_t==1,], y_t[d_t==1])
-  iates_mat[,2] = predict(rf1, x_v)$predictions - predict(rf0, x_v)$predictions
-
-  # Estimate RF nuisance parameters
-  index = caret::createFolds(y_t, k = 2)
-
-  np = nuisance_cf_grf(y_t,d_t,x_t,index)
-
-  # MOMs with RF
-  estimator_nm = list(mom_ipw_grf,mom_dr_grf)
-  for (j in 1:2) {
-    iates_mat[,j+2] = do.call(cf_dml1,list(estimator_nm[[j]],y_t,d_t,x_t,np,x_v,index))
+  if ("RF CMR" %in% estimators){
+    # CMR Random Forest
+    rf0 = regression_forest(x_t[d_t==0,], y_t[d_t==0])
+    rf1 = regression_forest(x_t[d_t==1,], y_t[d_t==1])
+    IATEs[['RF CMR']] = as.numeric(predict(rf1, x_v)$predictions - predict(rf0, x_v)$predictions)
+  }
+  if ("CF" %in% estimators){
+    # Causal Forest
+    cf = causal_forest(x_t, y_t, d_t, Y.hat = rep(0,n), W.hat = rep(0,n))
+    IATEs[["CF"]] = as.numeric(predict(cf,x_v)$predictions)
   }
 
-  # Causal Forest
-  cf = causal_forest(x_t, y_t, d_t, Y.hat = rep(0,n), W.hat = rep(0,n))
-  iates_mat[,5] = predict(cf,x_v)$predictions
+  ## modified outcome models  RF - fit nuisance fns first
+  if (sum(c("RF MOM IPW", "RF MOM DR")  %in% estimators)){
+        np = nuisance_cf_grf(y_t,d_t,x_t,index)
+  }
 
-  # Causal Forest with local centering
-  cf_lc = causal_forest(x_t, y_t, d_t, Y.hat = np[,2], W.hat = np[,1])
-  iates_mat[,6] = predict(cf_lc,x_v)$predictions
+  if ("RF MOM IPW" %in% estimators){
+    IATEs[['RF MOM IPW']] = as.numeric(do.call(cf_dml1,
+            list(mom_ipw_grf, y_t, d_t, x_t, np, x_v, index)
+            ))
+  }
 
+  if ("RF MOM DR" %in% estimators){
+    IATEs[["RF MOM DR"]] = as.numeric(do.call(cf_dml1,
+            list(mom_dr_grf, y_t, d_t, x_t, np, x_v, index)
+            ))
+  }
+
+  if ("CF LC" %in% estimators){
+    # Causal Forest with local centering
+    cf_lc = causal_forest(x_t, y_t, d_t, Y.hat = np[,2], W.hat = np[,1])
+    IATEs[["CF LC"]] = as.numeric(predict(cf_lc,x_v)$predictions)
+  }
+
+  ######################################################################
   ### Lasso based methods
-
-  # Infeasible Lasso
-  lasso_inf = cv.glmnet(x_t, tau_t)
-  iates_mat[,7] = predict(lasso_inf, x_v)
-
-  # CMR Lasso
-  lasso0 = cv.glmnet(x_t[d_t==0,], y_t[d_t==0])
-  lasso1 = cv.glmnet(x_t[d_t==1,], y_t[d_t==1])
-  iates_mat[,8] = predict(lasso1, x_v) - predict(lasso0, x_v)
-
-  # Estimate Lasso nuisance parameters with same index
-  np = nuisance_cf_glmnet(y_t,d_t,x_t,index)
-
-  # MOMs, MCMs and RL with Lasso
-  estimator_nm = list(mom_ipw_glmnet,mom_dr_glmnet,
-                      mcm_glmnet,mcm_ea_glmnet,rl_glmnet)
-  for (j in 1:5) {
-    iates_mat[,j+8] = do.call(cf_dml1,list(estimator_nm[[j]],y_t,d_t,x_t,np,x_v,index))
+  ######################################################################
+  if ("LASSO CMR" %in% estimators){
+    # CMR Lasso
+    lasso0 = cv.glmnet(x_t[d_t==0,], y_t[d_t==0])
+    lasso1 = cv.glmnet(x_t[d_t==1,], y_t[d_t==1])
+    IATEs[["LASSO CMR"]] = as.numeric(predict(lasso1, x_v) - predict(lasso0, x_v))
   }
 
-  return(iates_mat)
+  # need estimates of Lasso nuisance parameters for next 5 estimators
+  if (sum(c("Lasso MOM IPW", "Lasso MOM DR", "Lasso MCM", "Lasso MCM EA", "Lasso RL")
+        %in% estimators)){
+    np = nuisance_cf_glmnet(y_t, d_t, x_t, index)
+  }
+
+  if ("LASSO MOM IPW" %in% estimators){
+    IATEs[["LASSO MOM IPW"]] = as.numeric(do.call(cf_dml1,
+                                list(mom_ipw_glmnet, y_t, d_t, x_t, np, x_v, index)
+                              ))
+  }
+
+  if ("LASSO MOM DR" %in% estimators){
+    IATEs[["LASSO MOM DR"]] = as.numeric(do.call(cf_dml1,
+                                list(mom_dr_glmnet, y_t, d_t, x_t, np, x_v, index)
+                              ))
+  }
+
+  if ("LASSO MCM" %in% estimators){
+    IATEs[["LASSO MCM"]] = as.numeric(do.call(cf_dml1,
+                                list(mcm_glmnet, y_t, d_t, x_t, np, x_v, index)
+                              ))
+  }
+
+  if ("LASSO MCM EA" %in% estimators){
+    IATEs[["LASSO MCM EA"]] = as.numeric(do.call(cf_dml1,
+                                list(mcm_ea_glmnet, y_t, d_t, x_t, np, x_v, index)
+                              ))
+  }
+
+  if ("LASSO RL" %in% estimators){
+    IATEs[["LASSO RL"]] = as.numeric(do.call(cf_dml1,
+                                list(rl_glmnet, y_t, d_t, x_t, np, x_v, index)
+                              ))
+  }
+
+  # additional estimators go here
+  return(IATEs)
 }
-
-

--- a/README.md
+++ b/README.md
@@ -1,37 +1,63 @@
-# CATEs
-Implementation of all estimators that are applied in the Empirical Monte Carlo Study of [Knaus](https://mcknaus.github.io/), [Lechner](https://www.michael-lechner.eu/) and [Strittmatter](http://www.anthonystrittmatter.com/home) (2018). They are based on the packages [grf](https://github.com/grf-labs/grf) and [glmnet](https://github.com/cran/glmnet).
+# CATEs Estimators
+
+Caller package to implement multiple CATE estimators.
+
+Fork of [CATEs](https://github.com/MCKnaus/CATEs): implementation of
+all estimators that are applied in the Empirical Monte Carlo Study of
+[Knaus](https://mcknaus.github.io/),
+[Lechner](https://www.michael-lechner.eu/) and
+[Strittmatter](http://www.anthonystrittmatter.com/home) (2018). They
+are based on the packages [grf](https://github.com/grf-labs/grf) and
+[glmnet](https://github.com/cran/glmnet).
 
 ## Example
-We have no permission to share the data used in the study. Therefore, the following example uses the observational data generating process of the example of [grf](https://github.com/grf-labs/grf) to illustrate how it works. The function IATEs is a wrapper for the underlying functions and uses all the default settings of the packages. If you want to have more control over the settings, use the respective functions in CATEs_utils.
 
 ```R
-# Download current version from Github
-library(devtools)
-install_github(repo="MCKnaus/CATEs")
-library(CATEs)
+library(pacman)
+source("R/IATEs.R")
+source("R/CATEs_utils.R")
 
-# Generate training sample
+p_load(glmnet, grf, caret)
+
+# %% # Generate training sample
 n = 4000; p = 20
-x_tr = matrix(rnorm(n * p), n, p)
-tau_tr = 1 / (1 + exp(-x_tr[, 3]))
-d_tr = rbinom(n ,1, 1 / (1 + exp(-x_tr[, 1] - x_tr[, 2])))
-y_tr = pmax(x_tr[, 2] + x_tr[, 3], 0) + rowMeans(x_tr[, 4:6]) / 2 + d_tr * tau_tr + rnorm(n)
+x_t = matrix(rnorm(n * p), n, p)
+tau_t = 1 / (1 + exp(-x_t[, 3]))
+d_t = rbinom(n ,1, 1 / (1 + exp(-x_t[, 1] - x_t[, 2])))
+y_t = pmax(x_t[, 2] + x_t[, 3], 0) + rowMeans(x_t[, 4:6]) / 2 + d_t * tau_t + rnorm(n)
 
-# Generate validation sample of same size
-x_val = matrix(rnorm(n * p), n, p)
-tau_val = 1 / (1 + exp(-x_val[, 3]))
+# %% # Generate validation sample of same size
+x_v     = matrix(rnorm(n * p), n, p)
+tau_v   = 1 / (1 + exp(-x_v[, 3]))
 
-# Apply all estimators to the training sample and predict IATEs for validation sample
-iates_mat = IATEs(y_tr,d_tr,x_tr,tau_tr,x_val)
+# %% without true τ_train (for use in applications)
+iates_list = IATEs(y_t, d_t, x_t, x_v)
+iates_list  |>  str()
+iates_df = as.data.frame(do.call(cbind, iates_list))
+iates_df |> str()
 
-# Calculate and print mean MSEs
-mMSE = colMeans((iates_mat - tau_val)^2)
-names(mMSE) = colnames(iates_mat)
-mMSE*1000
+# 'data.frame': 4000 obs. of  11 variables:
+#  $ RF CMR       : num  0.181 0.389 1.3 1.047 0.419 ...
+#  $ CF           : num  0.502 0.381 0.716 0.965 0.532 ...
+#  $ RF MOM IPW   : num  0.343 0.244 2.164 0.365 0.534 ...
+#  $ RF MOM DR    : num  0.399 0.353 1.066 0.414 0.483 ...
+#  $ CF LC        : num  0.415 0.333 0.605 0.475 0.47 ...
+#  $ LASSO CMR    : num  0.503 -0.144 1.478 0.624 0.33 ...
+#  $ LASSO MOM IPW: num  0.594 0.076 1.156 0.425 0.691 ...
+#  $ LASSO MOM DR : num  0.442 0.222 0.844 0.514 0.462 ...
+#  $ LASSO MCM    : num  0.6586 0.0472 1.266 0.4265 0.7341 ...
+#  $ LASSO MCM EA : num  0.36 0.224 0.686 0.453 0.398 ...
+#  $ LASSO RL     : num  0.357 0.301 0.614 0.493 0.38 ...
+#
+
+# %% # Calculate and print mean MSEs
+mMSE = colMeans((iates_df - tau_v)^2)
+names(mMSE) = colnames(iates_df)
+round(mMSE*1000, 2)  |> t()
+
 ```
-
 
 ## References
 
-Knaus, Lechner, Strittmatter (2018). Machine Learning Estimation of Heterogeneous Causal
+Knaus, Lechner, Strittmatter (2020). Machine Learning Estimation of Heterogeneous Causal
 Effects: Empirical Monte Carlo Evidence, [arXiv](https://arxiv.org/abs/1810.13237)


### PR DESCRIPTION
Original implementation used `grf` <1.0 syntax for tuning `tune.parameters = TRUE`, which was broken in [1.0](https://grf-labs.github.io/grf/CHANGELOG.html#changed-breaking-2).  This results in error message when running `IATEs` with current versions of `grf`.

Changed all calls of `grf` functions in `CATEs_utils.R` to reflect current syntax. This fixes the error.